### PR TITLE
feat: double major

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Keep looking to this file whenever I ask to do some tasks.
 
 ## Project Overview
 
-A course planning tool for NYU Shanghai students. React + Vite + Tailwind CSS v4. Students pick a major, drag/add courses into 8 semester slots (4 years), and track progress toward 128 graduation credits and requirement fulfillment.
+A course planning tool for NYU Shanghai students. React + Vite + Tailwind CSS v4. Students pick a major (plus an optional second major for double majors), drag/add courses into 8 semester slots (4 years), and track progress toward 128 graduation credits and requirement fulfillment.
 
 ## Tech Stack
 
@@ -102,6 +102,7 @@ create table public.plans (
   user_id text not null,
   name text not null default 'My Plan',
   major text not null default 'custom',
+  second_major text,                    -- optional double major (migration 018)
   student_name text default '',
   created_at timestamptz default now(),
   updated_at timestamptz default now()
@@ -262,7 +263,7 @@ src/
 - **SuggestionInbox** (`src/components/layout/SuggestionInbox.jsx`) — admin-only inbox with search, status/category filters, status updates, and private notes. Header shows it only for admins configured by `src/lib/feedbackAdmin.js` (`VITE_FEEDBACK_ADMIN_IDS`, `VITE_FEEDBACK_ADMIN_EMAILS`, plus the default feedback email), but Supabase access is enforced by RLS.
 - **Admin grants:** migration `014_feedback_admin_inbox_policies.sql` creates `public.feedback_admins` and admin read/update policies for `public.suggestions`. Add the admin's Clerk user ID to `public.feedback_admins` to unlock all suggestions in the inbox.
 - **Remote catch-up:** `supabase/snippets/catchup_remote.sql` includes the suggestions table, enrichment columns, feedback admin table, and inbox policies for projects whose hosted Supabase database has not run migrations `012`/`013`/`014` yet.
-- Header passes `onOpenSuggestion` and `onOpenSuggestionInbox` callbacks; `App.jsx` owns the `suggestionOpen` / `suggestionInboxOpen` state and passes `getToken`, `user`, `plan`, `major`, and `totalCredits` to the feedback components.
+- Header passes `onOpenSuggestion` and `onOpenSuggestionInbox` callbacks; `App.jsx` owns the `suggestionOpen` / `suggestionInboxOpen` state and passes `getToken`, `user`, `plan`, `major`, and `totalCredits` to the feedback components (with a double major, the `major` string is combined, e.g. `cs + economics`).
 
 ### Plan transfer exports
 
@@ -278,10 +279,20 @@ src/
 - `scripts/scrape-bulletin.mjs` crawls all 15 NYU undergraduate bulletins. Run it without `--school` to refresh everything and rebuild `scraped-data/all-courses.json`. Single-school runs (`--school <slug>`) preserve the combined file (and the per-school file when `--subject` is also set) — pass `--combine` to rebuild `all-courses.json` from per-school files without re-fetching.
 - Supabase multi-campus offerings live in `public.catalog_course_offerings` (migration `017_catalog_course_offerings.sql`). `catalog_courses.id` remains the canonical stable course ID used by saved plans; offerings carry `school_slug`, `subject_slug`, and `campus_label`.
 - `useCatalog()` loads all published catalog pages by default, pages through Supabase results, chunks relationship lookups, and merges remote offerings with local curated metadata so each runtime course has `campuses`.
-- Dynamic major-based categorization: `getEffectiveCategory(course, majorId)` in `src/lib/majorCourseRules.js` resolves the **effective** category (major-required, major-elective, etc.) based on the active major.
+- Dynamic major-based categorization: `getEffectiveCategory(course, majorId)` in `src/lib/majorCourseRules.js` resolves the **effective** category (major-required, major-elective, etc.) based on the active major. With a double major, use `getEffectiveCategoryForMajors(course, [major, secondMajor])` / `isCourseRelevantToMajors()` — the strongest category across the active majors wins (required > elective), falling back to the primary major's view.
 - Generated catalog fulfillment text is normalized in `src/lib/localCatalog.js`; common bulletin phrases for CORE Writing, Language, GPS/PoH/IPC/HPC/SSPC, Mathematics, Algorithmic Thinking, ED, and STS receive the corresponding `requirementIds`, and generated elective-category entries are promoted to the matching display category (`writing`, `language`, `gps`, or `core`) when appropriate.
 - Saved plans are refreshed through `mergeCourseWithLocalCatalog()` on load so existing catalog courses pick up current metadata, including inferred requirement IDs and campus labels, without losing selected credits.
 - Requirement progress counts active-major **effective** categories from `getEffectiveCategory()` rather than only raw stored course categories, so bars stay aligned with the category shown on course cards.
+
+### Double major
+
+- `usePlanner` exposes `secondMajor` / `setSecondMajor` next to `major` / `setMajor`. `normalizeSecondMajor(secondMajor, primaryMajor)` in `src/data/courses.js` enforces the invariants (known major id, distinct from the primary, otherwise `null`); picking the second major as the new primary clears the second major.
+- Persistence: localStorage payload field `secondMajor`; Supabase column `plans.second_major` (migration `018_add_second_major.sql`). The migration also extends `save_plan_with_courses` with `p_second_major` — `null` (stale clients that omit the param) preserves the stored value, `''` explicitly clears it. **Apply migration 018 before deploying the client**, since `planStorage` selects `second_major` explicitly.
+- Requirement tracking: `requirementProgress['second-major']` mirrors the `major` entry and carries `doubleCountedCourses` (courses that are major courses for *both* majors). The sidebar renders a "2nd Major" section and a double-count note; NYU Shanghai allows at most `DOUBLE_MAJOR_MAX_DOUBLE_COUNT` (2) double-counted courses between majors, so the note turns into an amber warning beyond that.
+- Free electives count only courses that are elective under the *combined* category; course cards, the picker, and the detail modal color by the combined category, so a course required by the second major shows as Major Required.
+- Study-away: the CS/DS advisory (max 3 major courses per study-away semester, advising notes) now triggers when either major is `cs` or `data-science` (this also fixed a dead `major === "ds"` check), and per-major `studyAwayNotes` from both majors are shown.
+- Transfer: JSON export/import round-trips `secondMajor`; PDF export shows both major labels. CSV stays course-rows-only.
+- Header UI: "+ 2nd major" ghost button (desktop) / "+" icon (mobile) reveals the second select; "×" removes it. Each major select excludes the other's current value.
 
 ### Course picker UX
 

--- a/docs/superpowers/specs/2026-06-12-double-major-design.md
+++ b/docs/superpowers/specs/2026-06-12-double-major-design.md
@@ -1,0 +1,93 @@
+# Double Major Setting — Design
+
+Date: 2026-06-12
+Status: Implemented
+
+## Goal
+
+Let a student declare an optional second major and have the planner treat
+courses, requirement tracking, exports, and advisories as belonging to both
+majors. Single-major users see no change.
+
+## Approach
+
+Additive `secondMajor` field (major id string or `null`) next to the existing
+`major` string, rather than converting `major` into an array. Rationale:
+
+- Backward compatible everywhere (old localStorage payloads, Supabase rows,
+  and JSON exports simply lack the field → `null`).
+- NYU Shanghai students declare at most two majors, so an array buys nothing.
+- Avoids touching the meaning of the existing `plans.major` column and every
+  `major` prop at once.
+
+Alternatives considered: `majors: string[]` (more general, but forces a
+migration of every persistence shape and export format for no real use case);
+a separate "compare majors" view (doesn't track combined progress, which is
+the point of declaring a double major).
+
+## Data model & persistence
+
+- `usePlanner`: `secondMajor` state + `setSecondMajor`. Normalization rules:
+  must be a known major id, must differ from `major`, anything else → `null`.
+  Changing the primary to the current second major clears the second major
+  (the UI prevents this by filtering options; the guard covers imports).
+- localStorage payload: adds `secondMajor`.
+- Supabase: migration `018_add_second_major.sql`
+  - `plans.second_major text` (nullable).
+  - `save_plan_with_courses` gains `p_second_major text default null`. The old
+    6-arg signature is dropped first so PostgREST doesn't see an ambiguous
+    overload. Sentinel semantics: `null` (old clients) preserves the stored
+    value; `''` (new clients with no second major) clears it. This prevents a
+    stale deployed client from wiping a second major saved elsewhere.
+  - `ensurePlan`/`load` select `second_major`; `importFromLocal` writes it.
+  - **The migration must be applied before deploying the client**, because
+    `load` selects the column explicitly (same rollout pattern as 002/015).
+- JSON export/import: `secondMajor` round-trips. CSV is course-rows-only and
+  unchanged. PDF export shows both major labels.
+
+## Requirement logic
+
+- `majorCourseRules.js` gains combined-major helpers:
+  - `getEffectiveCategoryForMajors(course, majorIds)` — strongest category
+    wins: `major-required` for either major → `major-required`, else
+    `major-elective` for either → `major-elective`, else the primary major's
+    effective category (which handles the "downgrade other majors' courses to
+    elective" rule).
+  - `isCourseRelevantToMajors(course, majorIds)` — relevant to any.
+- `usePlanner.requirementProgress`:
+  - `progress.major` — primary, unchanged shape.
+  - `progress['second-major']` — same shape, computed against the second
+    major, present only when one is set. Includes `doubleCountedCourses`
+    (courses that are major courses for both) so the sidebar can surface
+    NYU Shanghai's double-counting rule: **at most two courses may be
+    double-counted between two majors** (per the NYU Shanghai academic
+    bulletin / degree progress documentation).
+  - Free electives = elective under the *combined* category.
+  - Core requirement category matching uses the combined category (explicit
+    `requirementIds` matches still win, as today).
+- Study away: the CS/DS advisory now triggers if *either* major is CS or Data
+  Science. This also fixes a dead check (`major === "ds"`) — the real id is
+  `data-science`, so the DS advisory never fired before.
+
+## UI
+
+- **Header**: primary major select unchanged. When no second major: a ghost
+  "+ 2nd major" button (desktop) / "+" icon (mobile) reveals a second select
+  with a "Choose 2nd major…" placeholder. When set: second select plus an "×"
+  remove button. Each select excludes the other's current value.
+- **Requirements sidebar**: second "Major — X" section when set (shared
+  section builder with the primary). Below it, a double-count line: "N
+  course(s) double-count toward both majors", amber warning when N > 2 citing
+  the two-course policy.
+- **Course coloring** (cards, picker, detail modal): combined category, so a
+  course required by the second major shows as Major Required.
+- **Course picker**: relevance sorting and category filter use both majors.
+- **Suggestion modal**: feedback payload's `major` becomes
+  `"cs + economics"`-style combined string (no schema change).
+
+## Testing
+
+`node --test` on `src/lib` (the repo's existing pattern — no React test
+infra): combined category precedence, relevance, and JSON import/export
+round-trip incl. legacy payloads without `secondMajor`. UI verified via
+`npm run build` + lint.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,8 @@ function AppContent() {
     plan,
     major,
     setMajor,
+    secondMajor,
+    setSecondMajor,
     studentName,
     addCourse,
     removeCourse,
@@ -119,6 +121,8 @@ function AppContent() {
       <Header
         major={major}
         setMajor={setMajor}
+        secondMajor={secondMajor}
+        setSecondMajor={setSecondMajor}
         totalCredits={totalCredits}
         theme={theme}
         toggleTheme={toggleTheme}
@@ -159,6 +163,7 @@ function AppContent() {
               prereqWarnings={prereqWarnings}
               onCourseClick={setDetailCourse}
               major={major}
+              secondMajor={secondMajor}
               onOpenStudyAway={(semesterId) => {
                 setStudyAwayFocusSemester(semesterId);
                 setStudyAwayPickerOpen(true);
@@ -178,6 +183,7 @@ function AppContent() {
             totalCredits={totalCredits}
             allPlannedCourses={allPlannedCourses}
             major={major}
+            secondMajor={secondMajor}
             collapsed={isSidebarCollapsed}
             onToggleCollapsed={() => setIsSidebarCollapsed((prev) => !prev)}
           />
@@ -239,6 +245,7 @@ function AppContent() {
                 totalCredits={totalCredits}
                 allPlannedCourses={allPlannedCourses}
                 major={major}
+                secondMajor={secondMajor}
                 collapsed={false}
               />
             </div>
@@ -255,6 +262,7 @@ function AppContent() {
           isCourseInPlan={isCourseInPlan}
           getCourseSemester={getCourseSemester}
           major={major}
+          secondMajor={secondMajor}
           defaultCampus={getDefaultCampusForSemester(pickerSemester, studyAway)}
         />
       )}
@@ -264,6 +272,7 @@ function AppContent() {
           course={detailCourse}
           prereqWarnings={prereqWarnings}
           major={major}
+          secondMajor={secondMajor}
           onClose={() => setDetailCourse(null)}
         />
       )}
@@ -271,6 +280,7 @@ function AppContent() {
       {studyAwayPickerOpen && (
         <StudyAwayPicker
           major={major}
+          secondMajor={secondMajor}
           studyAway={studyAway}
           warnings={studyAwayWarnings}
           initialSemester={studyAwayFocusSemester}
@@ -288,7 +298,7 @@ function AppContent() {
           getToken={getToken}
           user={user}
           plan={plan}
-          major={major}
+          major={secondMajor ? `${major} + ${secondMajor}` : major}
           totalCredits={totalCredits}
         />
       )}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Moon,
   Sun,
@@ -5,6 +6,8 @@ import {
   AlertTriangle,
   Inbox,
   MessageSquare,
+  Plus,
+  X,
 } from "lucide-react";
 import { UserButton } from "@clerk/react";
 import { MAJORS } from "../../data/courses";
@@ -23,6 +26,8 @@ const clerkAppearance = {
 export default function Header({
   major,
   setMajor,
+  secondMajor = null,
+  setSecondMajor,
   totalCredits,
   theme,
   toggleTheme,
@@ -40,6 +45,24 @@ export default function Header({
   canViewSuggestionInbox = false,
   onOpenSuggestionInbox,
 }) {
+  // Transient "choose your 2nd major" state before one is picked.
+  const [addingSecondMajor, setAddingSecondMajor] = useState(false);
+
+  const showSecondMajorSelect = !!secondMajor || addingSecondMajor;
+  const secondMajorOptions = MAJORS.filter((m) => m.id !== major);
+  const primaryMajorOptions = MAJORS.filter((m) => m.id !== secondMajor);
+
+  const handleSecondMajorChange = (value) => {
+    if (typeof setSecondMajor === "function") setSecondMajor(value);
+    // Once picked, the select stays visible because secondMajor is set.
+    setAddingSecondMajor(false);
+  };
+
+  const removeSecondMajor = () => {
+    setAddingSecondMajor(false);
+    if (typeof setSecondMajor === "function") setSecondMajor(null);
+  };
+
   const hasStudyAwayIssues =
     studyAwayWarningCount > 0 || hasIncompleteStudyAway;
   const studyAwayLabel =
@@ -84,12 +107,24 @@ export default function Header({
               backgroundPosition: "right 10px center",
             }}
           >
-            {MAJORS.map((m) => (
+            {primaryMajorOptions.map((m) => (
               <option key={m.id} value={m.id}>
                 {m.label}
               </option>
             ))}
           </select>
+
+          {!showSecondMajorSelect && (
+            <button
+              type="button"
+              onClick={() => setAddingSecondMajor(true)}
+              className="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground cursor-pointer min-h-[36px] min-w-[36px] flex items-center justify-center border border-border/50 shrink-0"
+              title="Add second major"
+              aria-label="Add second major"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          )}
 
           <div className="flex items-baseline gap-1 shrink-0">
             <span className="text-lg tabular-nums leading-none">
@@ -98,6 +133,46 @@ export default function Header({
             <span className="text-[11px] text-muted-foreground">cr</span>
           </div>
         </div>
+
+        {showSecondMajorSelect && (
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-[11px] uppercase tracking-wider text-muted-foreground">
+              2nd major
+            </span>
+            <select
+              className="flex-1 min-w-0 text-sm text-foreground bg-transparent border border-border/50 rounded-md pl-3 pr-8 py-2 outline-none cursor-pointer appearance-none truncate"
+              value={secondMajor || ""}
+              onChange={(e) => handleSecondMajorChange(e.target.value)}
+              aria-label="Select second major"
+              style={{
+                backgroundImage:
+                  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>\")",
+                backgroundRepeat: "no-repeat",
+                backgroundPosition: "right 10px center",
+              }}
+            >
+              {!secondMajor && (
+                <option value="" disabled>
+                  Choose 2nd major…
+                </option>
+              )}
+              {secondMajorOptions.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={removeSecondMajor}
+              className="p-2 rounded-md hover:bg-accent transition-colors text-muted-foreground cursor-pointer min-h-[36px] min-w-[36px] flex items-center justify-center border border-border/50 shrink-0"
+              title="Remove second major"
+              aria-label="Remove second major"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
 
         <div className="flex items-center gap-1.5">
           <button
@@ -136,6 +211,7 @@ export default function Header({
           <PlanMenu
             plan={plan}
             major={major}
+            secondMajor={secondMajor}
             studentName={studentName}
             studyAway={studyAway}
             totalCredits={totalCredits}
@@ -203,12 +279,57 @@ export default function Header({
             onChange={(e) => setMajor(e.target.value)}
             aria-label="Select major"
           >
-            {MAJORS.map((m) => (
+            {primaryMajorOptions.map((m) => (
               <option key={m.id} value={m.id}>
                 {m.label}
               </option>
             ))}
           </select>
+
+          {showSecondMajorSelect ? (
+            <div className="flex min-w-0 items-center gap-1">
+              <span className="text-sm text-muted-foreground/70" aria-hidden="true">
+                +
+              </span>
+              <select
+                className="min-w-0 max-w-44 lg:max-w-none text-sm text-muted-foreground bg-transparent border-none outline-none cursor-pointer appearance-none pr-4"
+                value={secondMajor || ""}
+                onChange={(e) => handleSecondMajorChange(e.target.value)}
+                aria-label="Select second major"
+              >
+                {!secondMajor && (
+                  <option value="" disabled>
+                    Choose 2nd major…
+                  </option>
+                )}
+                {secondMajorOptions.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={removeSecondMajor}
+                className="p-1 rounded-md hover:bg-accent transition-colors text-muted-foreground cursor-pointer"
+                title="Remove second major"
+                aria-label="Remove second major"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAddingSecondMajor(true)}
+              className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/60 px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer whitespace-nowrap"
+              title="Add second major"
+              aria-label="Add second major"
+            >
+              <Plus className="h-3 w-3" />
+              <span>2nd major</span>
+            </button>
+          )}
         </div>
 
         <div className="flex items-center justify-end gap-3">
@@ -257,6 +378,7 @@ export default function Header({
           <PlanMenu
             plan={plan}
             major={major}
+            secondMajor={secondMajor}
             studentName={studentName}
             studyAway={studyAway}
             totalCredits={totalCredits}

--- a/src/components/layout/PlanMenu.jsx
+++ b/src/components/layout/PlanMenu.jsx
@@ -62,6 +62,7 @@ function resolveImportParser(file) {
 export default function PlanMenu({
   plan,
   major,
+  secondMajor = null,
   studentName,
   studyAway,
   totalCredits,
@@ -135,6 +136,7 @@ export default function PlanMenu({
       const result = exportPlanAsPDF({
         plan,
         major,
+        secondMajor,
         studentName,
         studyAway,
         totalCredits,

--- a/src/components/layout/RequirementsSidebar.jsx
+++ b/src/components/layout/RequirementsSidebar.jsx
@@ -1,7 +1,13 @@
 import { useState, useMemo } from 'react';
-import { ChevronDown, CheckCircle2, Circle, ChevronsLeft, ChevronsRight } from 'lucide-react';
-import { CORE_REQUIREMENTS, GRADUATION_CREDITS, CATEGORIES, getMajorRequirement } from '../../data/courses';
-import { getEffectiveCategory } from '../../lib/majorCourseRules';
+import { ChevronDown, CheckCircle2, Circle, ChevronsLeft, ChevronsRight, AlertTriangle, Info } from 'lucide-react';
+import {
+  CORE_REQUIREMENTS,
+  GRADUATION_CREDITS,
+  CATEGORIES,
+  DOUBLE_MAJOR_MAX_DOUBLE_COUNT,
+  getMajorRequirement,
+} from '../../data/courses';
+import { getEffectiveCategoryForMajors } from '../../lib/majorCourseRules';
 
 function RequirementCategory({ requirement }) {
   const hasItems = Array.isArray(requirement.items) && requirement.items.length > 0;
@@ -71,6 +77,31 @@ function RequirementCategory({ requirement }) {
         />
       </div>
 
+      {Array.isArray(requirement.doubleCounted) &&
+        requirement.doubleCounted.length > 0 && (
+          <div
+            className={`mb-4 flex items-start gap-2 text-xs ${
+              requirement.doubleCounted.length > DOUBLE_MAJOR_MAX_DOUBLE_COUNT
+                ? 'text-amber-600 dark:text-amber-400'
+                : 'text-muted-foreground'
+            }`}
+          >
+            {requirement.doubleCounted.length > DOUBLE_MAJOR_MAX_DOUBLE_COUNT ? (
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            ) : (
+              <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+            )}
+            <span>
+              {requirement.doubleCounted.length} course
+              {requirement.doubleCounted.length === 1 ? '' : 's'} double-count
+              toward both majors
+              {requirement.doubleCounted.length > DOUBLE_MAJOR_MAX_DOUBLE_COUNT
+                ? ` — NYU Shanghai allows at most ${DOUBLE_MAJOR_MAX_DOUBLE_COUNT}; confirm with your advisor.`
+                : '.'}
+            </span>
+          </div>
+        )}
+
       {hasItems && isExpanded && (
         <div className="space-y-2 ml-1">
           {requirement.items.map((item, index) => (
@@ -110,8 +141,60 @@ function RequirementCategory({ requirement }) {
   );
 }
 
-function buildRequirements(requirementProgress, allPlannedCourses, major) {
+function buildMajorSection({ majorId, progress, planned, titlePrefix }) {
+  const majorDef = getMajorRequirement(majorId);
+  if (!majorDef || !progress) return null;
+
+  const majorItems = [];
+  for (const req of majorDef.requiredCourses || []) {
+    majorItems.push({
+      name: req.label,
+      completed: planned.some((c) => c.id === req.courseId),
+    });
+  }
+  for (const group of majorDef.selectOneCourses || []) {
+    const needed = group.count || 1;
+    const matchedCount = planned.filter((c) =>
+      group.courseIds.includes(c.id)
+    ).length;
+    majorItems.push({
+      name: group.label,
+      completed: matchedCount >= needed,
+      progress: needed > 1 ? `${matchedCount}/${needed}` : undefined,
+    });
+  }
+  if (majorDef.capstone) {
+    majorItems.push({
+      name: majorDef.capstone.label,
+      completed: planned.some((c) => c.id === majorDef.capstone.courseId),
+    });
+  }
+  if (!majorDef.isConfigured) {
+    majorItems.push({
+      name: majorDef.notes,
+      completed: false,
+    });
+  }
+
+  return {
+    category: `${titlePrefix} — ${majorDef.label}`,
+    completed: progress.creditsTaken,
+    required: progress.creditsNeeded,
+    requiredLabel: majorDef.isConfigured ? progress.creditsNeeded : 'TBD',
+    progressDenominator: majorDef.isConfigured ? progress.creditsNeeded : 1,
+    fulfilled: majorDef.isConfigured ? progress.fulfilled : false,
+    items: majorItems,
+  };
+}
+
+function buildRequirements(
+  requirementProgress,
+  allPlannedCourses,
+  major,
+  secondMajor
+) {
   const planned = allPlannedCourses || [];
+  const activeMajors = [major, secondMajor];
   const requirements = [];
 
   function isSubcourseCompleted(sub) {
@@ -131,7 +214,10 @@ function buildRequirements(requirementProgress, allPlannedCourses, major) {
     const requirement = CORE_REQUIREMENTS.find((r) => r.id === requirementId);
     if (!requirement || requirement.category === 'core') return false;
 
-    return getEffectiveCategory(course, major) === requirement.category;
+    return (
+      getEffectiveCategoryForMajors(course, activeMajors) ===
+      requirement.category
+    );
   }
 
   // Core Requirements
@@ -173,48 +259,31 @@ function buildRequirements(requirementProgress, allPlannedCourses, major) {
     items: coreItems,
   });
 
-  // Major
-  const majorDef = getMajorRequirement(major);
-  const majorProgress = requirementProgress['major'];
-  if (majorDef && majorProgress) {
-    const majorItems = [];
-    for (const req of majorDef.requiredCourses || []) {
-      majorItems.push({
-        name: req.label,
-        completed: planned.some((c) => c.id === req.courseId),
-      });
-    }
-    for (const group of majorDef.selectOneCourses || []) {
-      const needed = group.count || 1;
-      const matchedCount = planned.filter((c) => group.courseIds.includes(c.id)).length;
-      majorItems.push({
-        name: group.label,
-        completed: matchedCount >= needed,
-        progress: needed > 1 ? `${matchedCount}/${needed}` : undefined,
-      });
-    }
-    if (majorDef.capstone) {
-      majorItems.push({
-        name: majorDef.capstone.label,
-        completed: planned.some((c) => c.id === majorDef.capstone.courseId),
-      });
-    }
-    if (!majorDef.isConfigured) {
-      majorItems.push({
-        name: majorDef.notes,
-        completed: false,
-      });
-    }
+  // Major(s)
+  const majorSection = buildMajorSection({
+    majorId: major,
+    progress: requirementProgress['major'],
+    planned,
+    titlePrefix: 'Major',
+  });
+  if (majorSection) requirements.push(majorSection);
 
-    requirements.push({
-      category: `Major — ${majorDef.label}`,
-      completed: majorProgress.creditsTaken,
-      required: majorProgress.creditsNeeded,
-      requiredLabel: majorDef.isConfigured ? majorProgress.creditsNeeded : 'TBD',
-      progressDenominator: majorDef.isConfigured ? majorProgress.creditsNeeded : 1,
-      fulfilled: majorDef.isConfigured ? majorProgress.fulfilled : false,
-      items: majorItems,
+  if (secondMajor) {
+    const secondProgress = requirementProgress['second-major'];
+    const secondSection = buildMajorSection({
+      majorId: secondMajor,
+      progress: secondProgress,
+      planned,
+      titlePrefix: '2nd Major',
     });
+    if (secondSection) {
+      secondSection.doubleCounted = Array.isArray(
+        secondProgress?.doubleCountedCourses
+      )
+        ? secondProgress.doubleCountedCourses
+        : [];
+      requirements.push(secondSection);
+    }
   }
 
   // Writing
@@ -250,7 +319,9 @@ function buildRequirements(requirementProgress, allPlannedCourses, major) {
   const electives = requirementProgress['electives'];
   if (electives) {
     const electiveItems = planned
-      .filter((c) => getEffectiveCategory(c, major) === 'elective')
+      .filter(
+        (c) => getEffectiveCategoryForMajors(c, activeMajors) === 'elective'
+      )
       .map((c) => ({
         name: c.name,
         completed: true,
@@ -273,12 +344,19 @@ export default function RequirementsSidebar({
   totalCredits,
   allPlannedCourses,
   major,
+  secondMajor = null,
   collapsed = false,
   onToggleCollapsed,
 }) {
   const requirements = useMemo(
-    () => buildRequirements(requirementProgress, allPlannedCourses, major),
-    [requirementProgress, allPlannedCourses, major]
+    () =>
+      buildRequirements(
+        requirementProgress,
+        allPlannedCourses,
+        major,
+        secondMajor
+      ),
+    [requirementProgress, allPlannedCourses, major, secondMajor]
   );
 
   const completionPercent = Math.min(

--- a/src/components/planner/CourseCard.jsx
+++ b/src/components/planner/CourseCard.jsx
@@ -6,7 +6,7 @@ import {
   compareCampuses,
   getCourseCampuses,
 } from '../../lib/campus';
-import { getEffectiveCategory } from '../../lib/majorCourseRules';
+import { getEffectiveCategoryForMajors } from '../../lib/majorCourseRules';
 
 function withAlpha(color, alpha) {
   if (typeof color !== 'string' || !color.startsWith('#')) {
@@ -41,10 +41,14 @@ export default function CourseCard({
   isDragging = false,
   hasPrereqWarning = false,
   major,
+  secondMajor = null,
 }) {
   const didDragRef = useRef(false);
 
-  const resolvedCategory = getEffectiveCategory(course, major);
+  const resolvedCategory = getEffectiveCategoryForMajors(course, [
+    major,
+    secondMajor,
+  ]);
   const categoryKey = typeof resolvedCategory === 'string'
     ? resolvedCategory.toLowerCase()
     : 'elective';

--- a/src/components/planner/CourseDetailModal.jsx
+++ b/src/components/planner/CourseDetailModal.jsx
@@ -11,7 +11,7 @@ import { CATEGORIES, CORE_REQUIREMENTS } from "../../data/courses";
 import useCatalog from "../../hooks/useCatalog";
 import { getCourseCampuses } from "../../lib/campus";
 import { LOCAL_CATALOG_BY_ID } from "../../lib/localCatalog";
-import { getEffectiveCategory } from "../../lib/majorCourseRules";
+import { getEffectiveCategoryForMajors } from "../../lib/majorCourseRules";
 import { serializePrerequisiteGroup } from "../../lib/prerequisites";
 import ReviewSummary from "../reviews/ReviewSummary";
 
@@ -19,6 +19,7 @@ export default function CourseDetailModal({
   course: passedCourse,
   prereqWarnings = {},
   major,
+  secondMajor = null,
   onClose,
 }) {
   const { coursesById } = useCatalog();
@@ -32,7 +33,10 @@ export default function CourseDetailModal({
     LOCAL_CATALOG_BY_ID.get(passedCourse.id) ||
     passedCourse;
 
-  const resolvedCategory = getEffectiveCategory(course, major);
+  const resolvedCategory = getEffectiveCategoryForMajors(course, [
+    major,
+    secondMajor,
+  ]);
   const categoryKey =
     typeof resolvedCategory === "string"
       ? resolvedCategory.toLowerCase()

--- a/src/components/planner/CoursePicker.jsx
+++ b/src/components/planner/CoursePicker.jsx
@@ -9,8 +9,8 @@ import {
   normalizeCampuses,
 } from "../../lib/campus";
 import {
-  getEffectiveCategory,
-  isCourseRelevantToMajor,
+  getEffectiveCategoryForMajors,
+  isCourseRelevantToMajors,
 } from "../../lib/majorCourseRules";
 import { LOCAL_CATALOG_COURSES } from "../../lib/localCatalog";
 
@@ -22,6 +22,7 @@ export default function CoursePicker({
   isCourseInPlan,
   getCourseSemester,
   major,
+  secondMajor = null,
   defaultCampus = "Shanghai",
 }) {
   const [tab, setTab] = useState("catalog");
@@ -68,6 +69,7 @@ export default function CoursePicker({
   );
 
   const filtered = useMemo(() => {
+    const activeMajors = [major, secondMajor];
     let list = availableCourses;
 
     if (filterDept) {
@@ -75,7 +77,7 @@ export default function CoursePicker({
     }
     if (filterCat) {
       list = list.filter(
-        (c) => getEffectiveCategory(c, major) === filterCat,
+        (c) => getEffectiveCategoryForMajors(c, activeMajors) === filterCat,
       );
     }
     if (filterCampus) {
@@ -92,12 +94,12 @@ export default function CoursePicker({
     }
 
     list = [...list].sort((a, b) => {
-      const aRel = isCourseRelevantToMajor(a, major) ? 0 : 1;
-      const bRel = isCourseRelevantToMajor(b, major) ? 0 : 1;
+      const aRel = isCourseRelevantToMajors(a, activeMajors) ? 0 : 1;
+      const bRel = isCourseRelevantToMajors(b, activeMajors) ? 0 : 1;
       if (aRel !== bRel) return aRel - bRel;
 
-      const aEffective = getEffectiveCategory(a, major);
-      const bEffective = getEffectiveCategory(b, major);
+      const aEffective = getEffectiveCategoryForMajors(a, activeMajors);
+      const bEffective = getEffectiveCategoryForMajors(b, activeMajors);
       const aCategoryLabel =
         CATEGORIES[aEffective]?.label || aEffective || "";
       const bCategoryLabel =
@@ -122,6 +124,7 @@ export default function CoursePicker({
     filterCat,
     filterCampus,
     major,
+    secondMajor,
     courseSortCollator,
   ]);
 
@@ -245,7 +248,10 @@ export default function CoursePicker({
                     getCourseSemester?.(course.id) ||
                     (isCourseInPlan(course.id) ? semesterId : null);
                   const inPlan = Boolean(placedSemesterId);
-                  const effectiveCategory = getEffectiveCategory(course, major);
+                  const effectiveCategory = getEffectiveCategoryForMajors(
+                    course,
+                    [major, secondMajor],
+                  );
                   const cat =
                     CATEGORIES[effectiveCategory] || CATEGORIES.elective;
                   const placedSemesterLabel =

--- a/src/components/planner/SemesterCard.jsx
+++ b/src/components/planner/SemesterCard.jsx
@@ -36,6 +36,7 @@ export default function SemesterCard({
   prereqWarnings = {},
   onCourseClick,
   major,
+  secondMajor = null,
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
   const isDragActive = Boolean(dragState?.courseId);
@@ -238,6 +239,7 @@ export default function SemesterCard({
                     hasPrereqWarning={Boolean(prereqWarnings[course.id])}
                     onClick={() => onCourseClick?.(course)}
                     major={major}
+                    secondMajor={secondMajor}
                   />
                 </div>
               ))}

--- a/src/components/planner/SemesterGrid.jsx
+++ b/src/components/planner/SemesterGrid.jsx
@@ -53,6 +53,7 @@ export default function SemesterGrid({
   prereqWarnings = {},
   onCourseClick,
   major,
+  secondMajor = null,
 }) {
   const [dragState, setDragState] = useState(createEmptyDragState);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -327,6 +328,7 @@ export default function SemesterGrid({
                 prereqWarnings={prereqWarnings}
                 onCourseClick={onCourseClick}
                 major={major}
+                secondMajor={secondMajor}
               />
             );
           })}

--- a/src/components/planner/StudyAwayPicker.jsx
+++ b/src/components/planner/StudyAwayPicker.jsx
@@ -60,6 +60,7 @@ function getSemesterHint(semesterId) {
 
 export default function StudyAwayPicker({
   major,
+  secondMajor = null,
   studyAway,
   warnings,
   initialSemester,
@@ -108,8 +109,13 @@ export default function StudyAwayPicker({
     (selectedCount / STUDY_AWAY.maxSemesters) * 100,
     100,
   );
-  const isCsDsMajor = major === "cs" || major === "ds";
-  const majorNote = MAJOR_REQUIREMENTS[major]?.studyAwayNotes;
+  const activeMajors = [major, secondMajor].filter(Boolean);
+  const isCsDsMajor = activeMajors.some(
+    (majorId) => majorId === "cs" || majorId === "data-science",
+  );
+  const majorNotes = activeMajors
+    .map((majorId) => MAJOR_REQUIREMENTS[majorId]?.studyAwayNotes)
+    .filter(Boolean);
   const missingSiteCount = sortedSelectedSemesters.filter(
     (semesterId) => !studyAway.locations[semesterId],
   ).length;
@@ -568,7 +574,9 @@ export default function StudyAwayPicker({
                     <Info className="h-3.5 w-3.5" />
                     <h3>CS/DS advising</h3>
                   </div>
-                  {majorNote ? <p>{majorNote}</p> : null}
+                  {majorNotes.map((note) => (
+                    <p key={note}>{note}</p>
+                  ))}
                   <ul>
                     {(STUDY_AWAY.csdsAdvisingNotes || []).map((note) => (
                       <li key={note}>{note}</li>

--- a/src/data/courses.js
+++ b/src/data/courses.js
@@ -1137,6 +1137,22 @@ export function getMajorLabel(majorId) {
   return MAJORS.find((major) => major.id === majorId)?.label || 'Selected Major';
 }
 
+export function isKnownMajorId(majorId) {
+  return MAJORS.some((major) => major.id === majorId);
+}
+
+// NYU Shanghai allows at most two courses to be double-counted between the
+// requirements of two majors.
+export const DOUBLE_MAJOR_MAX_DOUBLE_COUNT = 2;
+
+// A second major must be a known major distinct from the primary; anything
+// else (unknown ids, the primary itself, non-strings) collapses to null.
+export function normalizeSecondMajor(secondMajor, primaryMajor) {
+  if (typeof secondMajor !== 'string' || !secondMajor) return null;
+  if (secondMajor === primaryMajor) return null;
+  return isKnownMajorId(secondMajor) ? secondMajor : null;
+}
+
 export function getMajorRequirement(majorId) {
   const configured = MAJOR_REQUIREMENTS[majorId];
   if (configured) {

--- a/src/hooks/usePlanner.js
+++ b/src/hooks/usePlanner.js
@@ -3,10 +3,14 @@ import {
   SEMESTERS,
   CORE_REQUIREMENTS,
   getMajorRequirement,
+  normalizeSecondMajor,
   STUDY_AWAY,
 } from "../data/courses";
 import { mergeCourseWithLocalCatalog } from "../lib/localCatalog";
-import { getEffectiveCategory } from "../lib/majorCourseRules";
+import {
+  getEffectiveCategory,
+  getEffectiveCategoryForMajors,
+} from "../lib/majorCourseRules";
 import { localStoragePlan, supabasePlan } from "../lib/planStorage";
 import { buildPrerequisiteWarnings } from "../lib/prerequisites";
 
@@ -87,7 +91,7 @@ function getUserProfileName(user) {
   return typeof rawName === "string" ? rawName.trim() : "";
 }
 
-function courseFulfillsRequirement(course, requirement, majorId) {
+function courseFulfillsRequirement(course, requirement, majorIds) {
   const requirementIds = Array.isArray(course?.requirementIds)
     ? course.requirementIds
     : [];
@@ -95,7 +99,7 @@ function courseFulfillsRequirement(course, requirement, majorId) {
     return true;
   }
 
-  const category = getEffectiveCategory(course, majorId);
+  const category = getEffectiveCategoryForMajors(course, majorIds);
   if (requirement.category === "core") {
     return false;
   }
@@ -108,13 +112,15 @@ function isEffectiveMajorCourse(course, majorId) {
   return category === "major-required" || category === "major-elective";
 }
 
-function isEffectiveElectiveCourse(course, majorId) {
-  return getEffectiveCategory(course, majorId) === "elective";
+function isEffectiveMajorCourseForMajors(course, majorIds) {
+  const category = getEffectiveCategoryForMajors(course, majorIds);
+  return category === "major-required" || category === "major-elective";
 }
 
 export default function usePlanner(user, getToken) {
   const [plan, setPlan] = useState(createEmptyPlan);
-  const [major, setMajor] = useState("cs");
+  const [major, setMajorState] = useState("cs");
+  const [secondMajor, setSecondMajorState] = useState(null);
   const [studentName, setStudentName] = useState("");
   const [studyAway, setStudyAway] = useState(createDefaultStudyAway);
   const [planId, setPlanId] = useState(null);
@@ -125,6 +131,25 @@ export default function usePlanner(user, getToken) {
   const skipNextSave = useRef(false);
 
   const isCloud = !!user;
+
+  // Selecting the current second major as primary drops the second major
+  // rather than leaving the same major declared twice.
+  const setMajor = useCallback((value) => {
+    setMajorState(value);
+    setSecondMajorState((prev) => (prev === value ? null : prev));
+  }, []);
+
+  const setSecondMajor = useCallback(
+    (value) => {
+      setSecondMajorState(normalizeSecondMajor(value, major));
+    },
+    [major],
+  );
+
+  const activeMajors = useMemo(
+    () => (secondMajor ? [major, secondMajor] : [major]),
+    [major, secondMajor],
+  );
 
   const flushSaveQueue = useCallback(async () => {
     if (saveInProgress.current) return;
@@ -138,6 +163,7 @@ export default function usePlanner(user, getToken) {
         await localStoragePlan.save({
           plan: snapshot.plan,
           major: snapshot.major,
+          secondMajor: snapshot.secondMajor,
           studentName: snapshot.studentName,
           studyAway: snapshot.studyAway,
         });
@@ -150,6 +176,7 @@ export default function usePlanner(user, getToken) {
                 planId: snapshot.planId,
                 plan: snapshot.plan,
                 major: snapshot.major,
+                secondMajor: snapshot.secondMajor,
                 studentName: snapshot.studentName,
                 studyAway: snapshot.studyAway,
               },
@@ -192,7 +219,8 @@ export default function usePlanner(user, getToken) {
           const didAutoFillName = !storedStudentName && !!profileStudentName;
 
           setPlan(deduplicatePlan(data.plan));
-          setMajor(data.major);
+          setMajorState(data.major);
+          setSecondMajorState(normalizeSecondMajor(data.secondMajor, data.major));
           setStudentName(resolvedStudentName);
           setStudyAway(normalizeStudyAway(data.studyAway));
           setPlanId(data.planId);
@@ -205,7 +233,10 @@ export default function usePlanner(user, getToken) {
         if (cancelled) return;
         if (data) {
           setPlan(deduplicatePlan(data.plan || createEmptyPlan()));
-          setMajor(data.major || "cs");
+          setMajorState(data.major || "cs");
+          setSecondMajorState(
+            normalizeSecondMajor(data.secondMajor, data.major || "cs"),
+          );
           setStudentName(data.studentName || "");
           setStudyAway(normalizeStudyAway(data.studyAway));
         }
@@ -236,6 +267,7 @@ export default function usePlanner(user, getToken) {
     const snapshot = {
       plan,
       major,
+      secondMajor,
       studentName,
       studyAway,
       isCloud,
@@ -254,6 +286,7 @@ export default function usePlanner(user, getToken) {
   }, [
     plan,
     major,
+    secondMajor,
     studentName,
     studyAway,
     isCloud,
@@ -338,22 +371,36 @@ export default function usePlanner(user, getToken) {
     setPlan(createEmptyPlan());
   }, []);
 
-  const replacePlan = useCallback((incoming) => {
-    if (!incoming || typeof incoming !== "object") return;
-    if (incoming.plan && typeof incoming.plan === "object") {
-      const merged = { ...createEmptyPlan(), ...incoming.plan };
-      setPlan(deduplicatePlan(merged));
-    }
-    if (typeof incoming.major === "string" && incoming.major) {
-      setMajor(incoming.major);
-    }
-    if (typeof incoming.studentName === "string") {
-      setStudentName(incoming.studentName);
-    }
-    if (incoming.studyAway !== undefined) {
-      setStudyAway(normalizeStudyAway(incoming.studyAway));
-    }
-  }, []);
+  const replacePlan = useCallback(
+    (incoming) => {
+      if (!incoming || typeof incoming !== "object") return;
+      if (incoming.plan && typeof incoming.plan === "object") {
+        const merged = { ...createEmptyPlan(), ...incoming.plan };
+        setPlan(deduplicatePlan(merged));
+      }
+      const nextMajor =
+        typeof incoming.major === "string" && incoming.major
+          ? incoming.major
+          : major;
+      if (nextMajor !== major) {
+        setMajorState(nextMajor);
+      }
+      if (incoming.secondMajor !== undefined) {
+        setSecondMajorState(normalizeSecondMajor(incoming.secondMajor, nextMajor));
+      } else {
+        // Imports without the field keep the current second major, unless the
+        // incoming primary collides with it.
+        setSecondMajorState((prev) => normalizeSecondMajor(prev, nextMajor));
+      }
+      if (typeof incoming.studentName === "string") {
+        setStudentName(incoming.studentName);
+      }
+      if (incoming.studyAway !== undefined) {
+        setStudyAway(normalizeStudyAway(incoming.studyAway));
+      }
+    },
+    [major],
+  );
 
   const mergePlan = useCallback((incoming) => {
     if (!incoming || typeof incoming !== "object") return;
@@ -501,7 +548,9 @@ export default function usePlanner(user, getToken) {
 
   const studyAwayWarnings = useMemo(() => {
     const warnings = [];
-    const isCsDsMajor = major === "cs" || major === "ds";
+    const isCsDsMajor = activeMajors.some(
+      (majorId) => majorId === "cs" || majorId === "data-science",
+    );
 
     if (studyAway.selectedSemesters.length > STUDY_AWAY.maxSemesters) {
       warnings.push({
@@ -538,7 +587,7 @@ export default function usePlanner(user, getToken) {
       if (!isCsDsMajor) return;
 
       const majorCourseCount = (plan[semesterId] || []).filter((course) =>
-        isEffectiveMajorCourse(course, major),
+        isEffectiveMajorCourseForMajors(course, activeMajors),
       ).length;
 
       if (majorCourseCount > STUDY_AWAY.maxMajorCoursesPerSemester) {
@@ -551,7 +600,7 @@ export default function usePlanner(user, getToken) {
     });
 
     return warnings;
-  }, [major, plan, studyAway]);
+  }, [activeMajors, plan, studyAway]);
 
   const allPlannedCourses = useMemo(() => {
     return Object.values(plan).flat();
@@ -574,7 +623,7 @@ export default function usePlanner(user, getToken) {
 
     CORE_REQUIREMENTS.forEach((req) => {
       const courses = allPlannedCourses.filter((course) =>
-        courseFulfillsRequirement(course, req, major),
+        courseFulfillsRequirement(course, req, activeMajors),
       );
       const creditsTaken = courses.reduce((sum, c) => sum + c.credits, 0);
       progress[req.id] = {
@@ -588,7 +637,8 @@ export default function usePlanner(user, getToken) {
     const languageProgress = progress.language;
     if (languageProgress) {
       const languageCourses = allPlannedCourses.filter(
-        (course) => courseFulfillsRequirement(course, languageProgress, major),
+        (course) =>
+          courseFulfillsRequirement(course, languageProgress, activeMajors),
       );
       const isEapCourse = (course) => EAP_COURSE_IDS.has(course.id);
 
@@ -658,8 +708,34 @@ export default function usePlanner(user, getToken) {
         : false,
     };
 
-    const electiveCourses = allPlannedCourses.filter((course) =>
-      isEffectiveElectiveCourse(course, major),
+    if (secondMajor) {
+      const secondMajorReq = getMajorRequirement(secondMajor);
+      const secondMajorCourses = allPlannedCourses.filter((course) =>
+        isEffectiveMajorCourse(course, secondMajor),
+      );
+      progress["second-major"] = {
+        id: "second-major",
+        label: secondMajorReq.label,
+        coursesNeeded: secondMajorReq.coursesNeeded,
+        creditsNeeded: secondMajorReq.creditsNeeded,
+        coursesTaken: secondMajorCourses.length,
+        creditsTaken: secondMajorCourses.reduce((sum, c) => sum + c.credits, 0),
+        fulfilled: secondMajorReq.isConfigured
+          ? secondMajorCourses.length >= secondMajorReq.coursesNeeded
+          : false,
+        doubleCountedCourses: secondMajorCourses
+          .filter((course) => isEffectiveMajorCourse(course, major))
+          .map((course) => ({
+            id: course.id,
+            name: course.name,
+            credits: course.credits,
+          })),
+      };
+    }
+
+    const electiveCourses = allPlannedCourses.filter(
+      (course) =>
+        getEffectiveCategoryForMajors(course, activeMajors) === "elective",
     );
     progress["electives"] = {
       id: "electives",
@@ -669,7 +745,7 @@ export default function usePlanner(user, getToken) {
     };
 
     return progress;
-  }, [allPlannedCourses, major]);
+  }, [allPlannedCourses, major, secondMajor, activeMajors]);
 
   const isCourseInPlan = useCallback(
     (courseId) => {
@@ -704,6 +780,8 @@ export default function usePlanner(user, getToken) {
     plan,
     major,
     setMajor,
+    secondMajor,
+    setSecondMajor,
     studentName,
     setStudentName,
     studyAway,

--- a/src/lib/campus.js
+++ b/src/lib/campus.js
@@ -27,23 +27,41 @@ export function abbreviateCampus(label) {
   return CAMPUS_ABBREV[label] || label;
 }
 
+// Every NYU undergraduate school physically located in New York City.
+// The set contains both the human-readable school names (e.g. "tandon",
+// "steinhardt") and the actual bulletin URL slugs (e.g. "engineering",
+// "culture-education-human-development"). When the scraper writes a
+// course's source slug, the slug used is whichever path the bulletin
+// site exposes — those NYC-based slugs need to map to "New York" too,
+// otherwise courses end up tagged "Engineering", "Business", "Arts",
+// etc. instead of the city.
 const NEW_YORK_SCHOOL_SLUGS = new Set([
-  "arts-science",
+  // Human-readable school names (used in some downstream places).
   "college-arts-science",
-  "dentistry",
   "gallatin",
-  "liberal-studies",
   "meyers",
-  "professional-studies",
   "rory-meyers-nursing",
   "silver",
-  "social-work",
   "stern",
   "steinhardt",
   "tandon",
   "tandon-engineering",
   "tisch",
   "wagner",
+  // Actual bulletin URL slugs (https://bulletins.nyu.edu/undergraduate/<slug>/).
+  "arts", // Tisch School of the Arts
+  "arts-science", // College of Arts and Science
+  "business", // Stern School of Business
+  "culture-education-human-development", // Steinhardt
+  "dentistry", // College of Dentistry
+  "engineering", // Tandon School of Engineering
+  "global-public-health", // School of Global Public Health
+  "individualized-study", // Gallatin
+  "liberal-studies",
+  "nursing", // Rory Meyers College of Nursing
+  "professional-studies",
+  "public-service", // Wagner Graduate School of Public Service
+  "social-work", // Silver School of Social Work
 ]);
 
 const CANONICAL_LABELS_BY_KEY = new Map(

--- a/src/lib/majorCourseRules.js
+++ b/src/lib/majorCourseRules.js
@@ -153,6 +153,44 @@ export function getEffectiveCategory(course, majorId) {
   return fallback;
 }
 
+function normalizeMajorIds(majorIds) {
+  const seen = new Set();
+  const ids = [];
+  for (const id of Array.isArray(majorIds) ? majorIds : [majorIds]) {
+    if (typeof id !== "string" || !id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Combined-major variant of getEffectiveCategory. The strongest category
+ * across the active majors wins (major-required > major-elective); when no
+ * major claims the course, the primary major's resolution applies so the
+ * "downgrade other majors' courses to elective" rule still holds.
+ */
+export function getEffectiveCategoryForMajors(course, majorIds) {
+  const ids = normalizeMajorIds(majorIds);
+  if (ids.length === 0) return getEffectiveCategory(course, null);
+
+  let sawMajorElective = false;
+  for (const id of ids) {
+    const category = getEffectiveCategory(course, id);
+    if (category === "major-required") return "major-required";
+    if (category === "major-elective") sawMajorElective = true;
+  }
+
+  if (sawMajorElective) return "major-elective";
+  return getEffectiveCategory(course, ids[0]);
+}
+
+export function isCourseRelevantToMajors(course, majorIds) {
+  const ids = normalizeMajorIds(majorIds);
+  if (ids.length === 0) return isCourseRelevantToMajor(course, null);
+  return ids.some((id) => isCourseRelevantToMajor(course, id));
+}
+
 export function isCourseRelevantToMajor(course, majorId) {
   if (!hasMajorCategory(course)) return false;
   if (!majorId || majorId === "custom") return true;

--- a/src/lib/majorCourseRules.test.js
+++ b/src/lib/majorCourseRules.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { getEffectiveCategory } from "./majorCourseRules.js";
+import {
+  getEffectiveCategory,
+  getEffectiveCategoryForMajors,
+  isCourseRelevantToMajors,
+} from "./majorCourseRules.js";
 
 test("active major requirements override a catalog course's generic category", () => {
   assert.equal(
@@ -14,4 +18,69 @@ test("major courses for other majors remain free electives", () => {
     getEffectiveCategory({ id: "PHYS-SHU-93", category: "major-required" }, "cs"),
     "elective",
   );
+});
+
+test("a course required by the second major shows as major-required", () => {
+  assert.equal(
+    getEffectiveCategoryForMajors({ id: "PHYS-SHU-93", category: "elective" }, [
+      "cs",
+      "physics",
+    ]),
+    "major-required",
+  );
+});
+
+test("a course required by the primary major stays major-required with a second major set", () => {
+  assert.equal(
+    getEffectiveCategoryForMajors(
+      { id: "CSCI-SHU-101", category: "major-required" },
+      ["cs", "physics"],
+    ),
+    "major-required",
+  );
+});
+
+test("major-required beats major-elective when the two majors disagree", () => {
+  // CSCI-SHU-360 is required for Data Science but only an open elective for CS.
+  assert.equal(
+    getEffectiveCategoryForMajors(
+      { id: "CSCI-SHU-360", category: "major-elective" },
+      ["cs", "data-science"],
+    ),
+    "major-required",
+  );
+});
+
+test("a course that is a major elective for either major shows as major-elective", () => {
+  assert.equal(
+    getEffectiveCategoryForMajors({ id: "CSCI-SHU-376", category: "elective" }, [
+      "physics",
+      "cs",
+    ]),
+    "major-elective",
+  );
+});
+
+test("a course in neither major's space falls back to the primary major's view", () => {
+  assert.equal(
+    getEffectiveCategoryForMajors(
+      { id: "PHYS-SHU-93", category: "major-required" },
+      ["business", "economics"],
+    ),
+    "elective",
+  );
+});
+
+test("combined category with one major matches the single-major resolution", () => {
+  const course = { id: "PHYS-SHU-93", category: "major-required" };
+  assert.equal(
+    getEffectiveCategoryForMajors(course, ["cs", null]),
+    getEffectiveCategory(course, "cs"),
+  );
+});
+
+test("relevance is satisfied by either major", () => {
+  const course = { id: "PHYS-SHU-93", category: "major-required" };
+  assert.equal(isCourseRelevantToMajors(course, ["cs"]), false);
+  assert.equal(isCourseRelevantToMajors(course, ["cs", "physics"]), true);
 });

--- a/src/lib/planStorage.js
+++ b/src/lib/planStorage.js
@@ -177,13 +177,14 @@ export const localStoragePlan = {
     return null;
   },
 
-  async save({ plan, major, studentName, studyAway }) {
+  async save({ plan, major, secondMajor, studentName, studyAway }) {
     try {
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
           plan,
           major,
+          secondMajor: secondMajor || null,
           studentName,
           studyAway: normalizeStudyAwayPayload(studyAway),
         }),
@@ -209,7 +210,7 @@ export const supabasePlan = {
     const { data: existing, error: existingError } = await db
       .from("plans")
       .select(
-        "id, name, major, student_name, study_away_semesters, study_away_locations",
+        "id, name, major, second_major, student_name, study_away_semesters, study_away_locations",
       )
       .eq("user_id", userId)
       .order("created_at", { ascending: true })
@@ -258,7 +259,7 @@ export const supabasePlan = {
         student_name: normalizedProfileName || "",
       })
       .select(
-        "id, name, major, student_name, study_away_semesters, study_away_locations",
+        "id, name, major, second_major, student_name, study_away_semesters, study_away_locations",
       )
       .single();
 
@@ -292,6 +293,7 @@ export const supabasePlan = {
         planId,
         plan,
         major: planRow.major || "cs",
+        secondMajor: planRow.second_major || null,
         studentName: planRow.student_name || "",
         studyAway: normalizeStudyAwayPayload({
           selectedSemesters: planRow.study_away_semesters || [],
@@ -304,7 +306,11 @@ export const supabasePlan = {
     }
   },
 
-  async save(userId, { planId, plan, major, studentName, studyAway }, getToken) {
+  async save(
+    userId,
+    { planId, plan, major, secondMajor, studentName, studyAway },
+    getToken,
+  ) {
     try {
       if (!userId) throw new Error("Cannot save a cloud plan without a user");
       const db = await getSupabaseDb(getToken);
@@ -312,6 +318,9 @@ export const supabasePlan = {
       const { error } = await db.rpc("save_plan_with_courses", {
         p_plan_id: planId,
         p_major: major,
+        // '' explicitly clears the second major; the RPC treats null (older
+        // clients that never send the param) as "keep the stored value".
+        p_second_major: secondMajor || "",
         p_student_name: studentName || "",
         p_study_away_semesters: normalizedStudyAway.selectedSemesters,
         p_study_away_locations: normalizedStudyAway.locations,
@@ -343,6 +352,7 @@ export const supabasePlan = {
       .update({
         name: buildPlanName(localStudentName),
         major: localData.major || "cs",
+        second_major: localData.secondMajor || null,
         student_name: localData.studentName || "",
         study_away_semesters: localData.studyAway?.selectedSemesters || [],
         study_away_locations: localData.studyAway?.locations || {},
@@ -357,6 +367,7 @@ export const supabasePlan = {
       planId: planRow.id,
       plan: localData.plan,
       major: localData.major || "cs",
+      secondMajor: localData.secondMajor || null,
       studentName: localData.studentName || "",
       studyAway: normalizeStudyAwayPayload(localData.studyAway),
     }, getToken);

--- a/src/lib/planTransfer.js
+++ b/src/lib/planTransfer.js
@@ -6,6 +6,7 @@ import {
   MAX_CREDITS_PER_SEMESTER,
   MIN_CREDITS_PER_SEMESTER,
   getMajorLabel,
+  normalizeSecondMajor,
 } from "../data/courses.js";
 import {
   LOCAL_CATALOG_BY_ID,
@@ -169,6 +170,7 @@ function resolveCourse(courseId, fallback) {
 export function exportPlanAsJSON({
   plan,
   major,
+  secondMajor,
   studentName,
   studyAway,
 }) {
@@ -178,6 +180,7 @@ export function exportPlanAsJSON({
     version: PLAN_EXPORT_VERSION,
     exportedAt: new Date().toISOString(),
     major: major || "cs",
+    secondMajor: normalizeSecondMajor(secondMajor, major),
     studentName: studentName || "",
     studyAway: normalizeStudyAwayPayload(studyAway),
     semesters: Object.fromEntries(
@@ -321,6 +324,7 @@ function semesterCreditState(credits, courseCount) {
 export function exportPlanAsPDF({
   plan,
   major,
+  secondMajor,
   studentName,
   studyAway,
   totalCredits,
@@ -366,7 +370,10 @@ export function exportPlanAsPDF({
   const filledSemesterCount = semesters.filter(
     (semester) => semester.courses.length > 0,
   ).length;
-  const majorLabel = getMajorLabel(major || "");
+  const resolvedSecondMajor = normalizeSecondMajor(secondMajor, major);
+  const majorLabel = resolvedSecondMajor
+    ? `${getMajorLabel(major || "")} · ${getMajorLabel(resolvedSecondMajor)}`
+    : getMajorLabel(major || "");
   const progressPercent = Math.max(
     0,
     Math.min(100, (resolvedTotalCredits / GRADUATION_CREDITS) * 100),
@@ -912,6 +919,7 @@ export async function importPlanFromJSON(file) {
   }
 
   const major = typeof parsed.major === "string" ? parsed.major : "cs";
+  const secondMajor = normalizeSecondMajor(parsed.secondMajor, major);
   const studentName =
     typeof parsed.studentName === "string" ? parsed.studentName : "";
   const studyAway = normalizeStudyAwayPayload(parsed.studyAway);
@@ -921,6 +929,7 @@ export async function importPlanFromJSON(file) {
   return {
     plan,
     major,
+    secondMajor,
     studentName,
     studyAway,
     summary,

--- a/src/lib/planTransfer.test.js
+++ b/src/lib/planTransfer.test.js
@@ -29,6 +29,8 @@ test("importPlanFromJSON imports semesters, major, and student name", async () =
   const imported = await importPlanFromJSON(file);
 
   assert.equal(imported.major, "business");
+  // Legacy export without a secondMajor field imports as single-major.
+  assert.equal(imported.secondMajor, null);
   assert.equal(imported.studentName, "Test Student");
   assert.equal(imported.plan["Y1-Fall"].length, 1);
   assert.equal(imported.plan["Y1-Fall"][0].id, "BUSF-SHU-202");
@@ -36,4 +38,41 @@ test("importPlanFromJSON imports semesters, major, and student name", async () =
     "Shanghai",
     "New York",
   ]);
+});
+
+test("importPlanFromJSON carries a valid secondMajor through", async () => {
+  const file = {
+    async text() {
+      return JSON.stringify({
+        kind: "nyu-shanghai-course-plan",
+        version: 2,
+        major: "cs",
+        secondMajor: "economics",
+        studentName: "",
+        semesters: {},
+      });
+    },
+  };
+
+  const imported = await importPlanFromJSON(file);
+  assert.equal(imported.major, "cs");
+  assert.equal(imported.secondMajor, "economics");
+});
+
+test("importPlanFromJSON drops an invalid or duplicate secondMajor", async () => {
+  const makeFile = (secondMajor) => ({
+    async text() {
+      return JSON.stringify({
+        kind: "nyu-shanghai-course-plan",
+        version: 2,
+        major: "cs",
+        secondMajor,
+        semesters: {},
+      });
+    },
+  });
+
+  assert.equal((await importPlanFromJSON(makeFile("not-a-major"))).secondMajor, null);
+  assert.equal((await importPlanFromJSON(makeFile("cs"))).secondMajor, null);
+  assert.equal((await importPlanFromJSON(makeFile(42))).secondMajor, null);
 });

--- a/supabase/migrations/018_add_second_major.sql
+++ b/supabase/migrations/018_add_second_major.sql
@@ -1,0 +1,93 @@
+-- Double major support: optional second major on plans, threaded through the
+-- transactional save RPC.
+--
+-- Apply this migration BEFORE deploying the client that selects
+-- plans.second_major (same rollout pattern as 002/015).
+
+alter table public.plans
+  add column if not exists second_major text;
+
+-- Adding a parameter changes the function signature, so drop the old 6-arg
+-- version first; otherwise PostgREST sees two overloads and RPC calls fail
+-- with an ambiguity error.
+drop function if exists public.save_plan_with_courses(uuid, text, text, text[], jsonb, jsonb);
+
+create or replace function public.save_plan_with_courses(
+  p_plan_id uuid,
+  p_major text,
+  p_student_name text,
+  p_study_away_semesters text[],
+  p_study_away_locations jsonb,
+  p_courses jsonb,
+  p_second_major text default null
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+begin
+  if jsonb_typeof(coalesce(p_courses, '[]'::jsonb)) <> 'array' then
+    raise exception 'p_courses must be a JSON array' using errcode = '22023';
+  end if;
+
+  update public.plans
+  set
+    major = coalesce(p_major, major),
+    -- null = parameter omitted (stale client): keep the stored value.
+    -- ''   = explicitly no second major: clear it.
+    second_major = case
+      when p_second_major is null then second_major
+      else nullif(p_second_major, '')
+    end,
+    student_name = coalesce(p_student_name, ''),
+    study_away_semesters = coalesce(p_study_away_semesters, '{}'::text[]),
+    study_away_locations = coalesce(p_study_away_locations, '{}'::jsonb)
+  where id = p_plan_id
+    and user_id = (select auth.jwt()->>'sub');
+
+  if not found then
+    raise exception 'Plan not found or access denied' using errcode = '42501';
+  end if;
+
+  delete from public.plan_courses
+  where plan_id = p_plan_id;
+
+  insert into public.plan_courses (
+    plan_id,
+    semester_id,
+    course_id,
+    position,
+    selected_credits,
+    course_snapshot,
+    custom_name,
+    custom_credits,
+    custom_category
+  )
+  select
+    p_plan_id,
+    course_row.semester_id,
+    course_row.course_id,
+    coalesce(course_row.position, 0),
+    course_row.selected_credits,
+    course_row.course_snapshot,
+    course_row.custom_name,
+    course_row.custom_credits,
+    course_row.custom_category
+  from jsonb_to_recordset(coalesce(p_courses, '[]'::jsonb)) as course_row(
+    semester_id text,
+    course_id text,
+    position int,
+    selected_credits int,
+    course_snapshot jsonb,
+    custom_name text,
+    custom_credits int,
+    custom_category text
+  )
+  where course_row.semester_id is not null
+    and course_row.course_id is not null;
+end;
+$$;
+
+revoke all on function public.save_plan_with_courses(uuid, text, text, text[], jsonb, jsonb, text) from public;
+grant execute on function public.save_plan_with_courses(uuid, text, text, text[], jsonb, jsonb, text) to authenticated;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Add double major support**: Introduce optional `secondMajor` field throughout the planner application (state management, persistence, UI components)
- **Update planner hooks**: Extend `usePlanner` to manage `secondMajor` state alongside primary major, including normalization and persistence
- **Database migration**: Add `second_major` column to `public.plans` table and update `save_plan_with_courses` RPC function signature (migration 018)
- **Multi-major course categorization**: Introduce `getEffectiveCategoryForMajors` and `isCourseRelevantToMajors` helpers for evaluating courses against multiple active majors
- **UI enhancements**: Update Header, RequirementsSidebar, CoursePicker, and other components to support second major selection, display, and double-count warnings
- **Plan import/export**: Extend JSON and PDF export functions to include `secondMajor` field; add support for reading/normalizing `secondMajor` on import
- **Local and cloud storage**: Update localStorage and Supabase plan persistence to include `secondMajor` field
- **Study-away advising**: Extend CS/DS advising logic to consider both majors when determining whether to display relevant guidance
- **Documentation**: Add comprehensive design specification and update AGENTS.md with double major feature details
- **Validation utilities**: Add `isKnownMajorId` and `normalizeSecondMajor` helpers for major validation
- **Test coverage**: Expand test suite for multi-major course categorization and plan import/export

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| adumannn | 825 | 112 |
| **Total** | **825** | **112** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->